### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/Thinaneshan6/9b05b3c9-cd46-428d-ad88-1654e050aacf/7525974d-ddc0-4bcc-9ff1-a47a25ac5a72/_apis/work/boardbadge/e56e21e2-25b6-4569-a339-787b075fcbf4)](https://dev.azure.com/Thinaneshan6/9b05b3c9-cd46-428d-ad88-1654e050aacf/_boards/board/t/7525974d-ddc0-4bcc-9ff1-a47a25ac5a72/Microsoft.RequirementCategory)
 # PafProject
 this is the payment API for the project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Thinaneshan6/9b05b3c9-cd46-428d-ad88-1654e050aacf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.